### PR TITLE
Docstring example

### DIFF
--- a/docstrings.py
+++ b/docstrings.py
@@ -1,0 +1,27 @@
+'''
+Author: Reid Dye
+
+This file shows how all files should be documented.
+This area should have a description of the file's contents.
+'''
+
+def divide(numerator: int|float, denomerators: list[int|float], integer: bool = True) -> list[int|float]:
+    """divides numerator by all of the numbers in divisors
+
+    Args:
+        numerator (int|float): the number to be divided
+        denomerators (list): a list of numbers to divide `numerator` by
+        integer (bool, optional): use integer division, if true. Defaults to True.
+
+    Raises:
+        AssertionError: raises an error if you try to divide by zero.
+
+    Returns:
+        list: the list of numbers from dividing numerator by all of the denomerators
+    """
+
+    assert not 0 in denomerators, "dividing by zero is not allowed"
+
+    if integer:
+        return [numerator//d for d in denomerators]
+    return [numerator/d for d in denomerators]

--- a/docstrings.py
+++ b/docstrings.py
@@ -5,7 +5,7 @@ This file shows how all files should be documented.
 This area should have a description of the file's contents.
 '''
 
-def divide(numerator: int|float, denomerators: list[int|float], integer: bool = True) -> list[int|float]:
+def divide(numerator: 'int|float', denomerators: 'list[int|float]', integer: 'bool' = True) -> 'list[int|float]':
     """divides numerator by all of the numbers in divisors
 
     Args:
@@ -20,8 +20,9 @@ def divide(numerator: int|float, denomerators: list[int|float], integer: bool = 
         list: the list of numbers from dividing numerator by all of the denomerators
     """
 
-    assert not 0 in denomerators, "dividing by zero is not allowed"
+    #TODO: make this error message more helpful
+    assert not 0 in denomerators, "panic! aaaaaah! something bad happened!" #check for illegal inputs
 
     if integer:
-        return [numerator//d for d in denomerators]
-    return [numerator/d for d in denomerators]
+        return [numerator//d for d in denomerators] # if integer is true, use integer division,
+    return [numerator/d for d in denomerators]      # otherwise use normal division


### PR DESCRIPTION
Made a file fully documented with the correct format.

## parts of the documentation: 
### header
the header is a multi-line comment with the primary author and a description o the file's contents.  
It briefly describes the big-picture purpose and function of the file.
### type hints
after each argument, you write the type of the argument.  You can specify the possibility for multiple types using a pipe: `int|bool` and list types like this: `list[int]`. These should all be strings. The return type should be specified similarly, after an arrow.
### docstrings
docstrings should be multi line strings that specify arguments, errors that could be raised, and the return value. Docstrings should be formatted like this:
```
"""_summary_

Args:
    _name_ (_type_): _description_

Raises:
    _error_type_: _description_

Returns:
    _return_type_:  _description_
"""
```
if any of these categories are empty, you can just omit them.

Comments should be helpful in explaining more of how the method actually works.

use #TODO description_of_thing_to_do to signal something that is in progress or that you need to remember to do.

